### PR TITLE
fix: unresponsive collapse btn on mobile

### DIFF
--- a/src/components/SiderMenu/SiderMenu.js
+++ b/src/components/SiderMenu/SiderMenu.js
@@ -50,7 +50,7 @@ export default class SiderMenu extends PureComponent {
   };
 
   render() {
-    const { logo, collapsed, onCollapse, fixSiderbar, theme } = this.props;
+    const { logo, collapsed, onCollapse, fixSiderbar, theme, isMobile } = this.props;
     const { openKeys } = this.state;
     const defaultProps = collapsed ? {} : { openKeys };
 
@@ -64,7 +64,11 @@ export default class SiderMenu extends PureComponent {
         collapsible
         collapsed={collapsed}
         breakpoint="lg"
-        onCollapse={onCollapse}
+        onCollapse={(collapse) => {
+          if (!isMobile) {
+            onCollapse(collapse);
+          }
+        }}
         width={256}
         theme={theme}
         className={siderClassName}

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -26,6 +26,8 @@ const SettingDrawer = React.lazy(() => import('@/components/SettingDrawer'));
 
 const { Content } = Layout;
 
+export const mobileQuery = "(max-width: 599px)";
+
 const query = {
   'screen-xs': {
     maxWidth: 575,
@@ -73,15 +75,6 @@ class BasicLayout extends React.Component {
       type: 'menu/getMenuData',
       payload: { routes, authority },
     });
-  }
-
-  componentDidUpdate(preProps) {
-    // After changing to phone mode,
-    // if collapsed is true, you need to click twice to display
-    const { collapsed, isMobile } = this.props;
-    if (isMobile && !preProps.isMobile && !collapsed) {
-      this.handleMenuCollapse(false);
-    }
   }
 
   getContext() {
@@ -230,7 +223,7 @@ export default connect(({ global, setting, menu: menuModel }) => ({
   breadcrumbNameMap: menuModel.breadcrumbNameMap,
   ...setting,
 }))(props => (
-  <Media query="(max-width: 599px)">
+  <Media query={mobileQuery}>
     {isMobile => <BasicLayout {...props} isMobile={isMobile} />}
   </Media>
 ));

--- a/src/models/global.js
+++ b/src/models/global.js
@@ -1,10 +1,11 @@
 import { queryNotices } from '@/services/api';
+import { mobileQuery } from '@/layouts/BasicLayout';
 
 export default {
   namespace: 'global',
 
   state: {
-    collapsed: false,
+    collapsed: window.matchMedia(mobileQuery).matches, // true if mobile
     notices: [],
     loadedAllNotices: false,
   },


### PR DESCRIPTION
Collapse button had to be pressed twice after resizing to mobile. Fixes this issue along with removing some of the dodgy code that caused the Sider to quickly open and close upon refresh of the page on mobile.